### PR TITLE
Infer on `.expr` when `Call` node has `.attrname`

### DIFF
--- a/codewatch/node_visitor.py
+++ b/codewatch/node_visitor.py
@@ -100,7 +100,7 @@ def count_calling_files(stats_namespace, expected_callable_qname):
             return call_node
 
         try:
-            inferred_types = call_node.func.inferred()
+            inferred_types = node_to_infer.inferred()
         except InferenceError:
             return call_node
 

--- a/codewatch/node_visitor.py
+++ b/codewatch/node_visitor.py
@@ -17,9 +17,7 @@ class NodeVisitor(TransformVisitor):
         CodewatchNodeAnnotations = namedtuple(
             "CodewatchNodeAnnotations", ["stats", "rel_file_path"]
         )
-        node._codewatch = CodewatchNodeAnnotations(
-            self.stats, self.rel_file_path
-        )
+        node._codewatch = CodewatchNodeAnnotations(self.stats, self.rel_file_path)
         return node
 
     def _transform(self, node):
@@ -69,7 +67,7 @@ def count_calling_files(stats_namespace, expected_callable_qname):
     if stats_namespace is None:
         raise Exception("count_calling_files() requires a valid namespace")
 
-    expected_callable_name = expected_callable_qname.split('.')[-1]
+    expected_callable_name = expected_callable_qname.split(".")[-1]
 
     def record_stats(stats, rel_file_path):
         stats = stats.namespaced(stats_namespace)
@@ -89,7 +87,9 @@ def count_calling_files(stats_namespace, expected_callable_qname):
         if callable_as_attribute:
             callable_name = call_node.func.attrname
             node_to_infer = call_node.func.expr
-            build_qname = lambda inferred_type: inferred_type.qname() + callable_name
+            build_qname = lambda inferred_type: ".".join(
+                [inferred_type.qname(), callable_name]
+            )
         else:
             callable_name = call_node.func.name
             node_to_infer = call_node.func
@@ -139,17 +139,13 @@ class NodeVisitorMaster(object):
         initialized_node_visitors = []
         for node, node_visitor_function in cls.node_visitor_registry:
             node_visitor_obj = NodeVisitor(stats, rel_file_path)
-            node_visitor_obj.register_transform(
-                node, node_visitor_function
-            )
+            node_visitor_obj.register_transform(node, node_visitor_function)
             initialized_node_visitors.append(node_visitor_obj)
         return initialized_node_visitors
 
     @classmethod
     def visit(cls, stats, node, rel_file_path):
-        node_visitors_initialized = cls._initialize_node_visitors(
-            stats, rel_file_path
-        )
+        node_visitors_initialized = cls._initialize_node_visitors(stats, rel_file_path)
 
         for node_visitor_initialized in node_visitors_initialized:
             node_visitor_initialized.visit(node)

--- a/codewatch/node_visitor.py
+++ b/codewatch/node_visitor.py
@@ -18,7 +18,9 @@ class NodeVisitor(TransformVisitor):
         CodewatchNodeAnnotations = namedtuple(
             "CodewatchNodeAnnotations", ["stats", "rel_file_path"]
         )
-        node._codewatch = CodewatchNodeAnnotations(self.stats, self.rel_file_path)
+        node._codewatch = CodewatchNodeAnnotations(
+            self.stats, self.rel_file_path
+        )
         return node
 
     def _transform(self, node):
@@ -57,7 +59,9 @@ def _astroid_interface_for_visitor(visitor_function):
 
 def visit(node_type, change_node_inference=None):
     def decorator(fn):
-        NodeVisitorMaster.register_visitor(node_type, fn, change_node_inference)
+        NodeVisitorMaster.register_visitor(
+            node_type, fn, change_node_inference
+        )
         return fn
 
     return decorator
@@ -117,7 +121,9 @@ class NodeVisitorMaster(object):
     node_visitor_registry = []
 
     @classmethod
-    def register_visitor(cls, node, visitor_function, change_node_inference=None):
+    def register_visitor(
+        cls, node, visitor_function, change_node_inference=None
+    ):
         wrapped = _astroid_interface_for_visitor(visitor_function)
 
         if not issubclass(node, NodeNG):
@@ -126,7 +132,9 @@ class NodeVisitorMaster(object):
                 "Please use a NodeNG subclass from the astroid.nodes module."
             )
 
-        cls.node_visitor_registry.append((node, wrapped, change_node_inference))
+        cls.node_visitor_registry.append(
+            (node, wrapped, change_node_inference)
+        )
 
     @classmethod
     def _initialize_node_visitors(cls, stats, rel_file_path):
@@ -149,7 +157,9 @@ class NodeVisitorMaster(object):
 
     @classmethod
     def visit(cls, stats, node, rel_file_path):
-        node_visitors_initialized = cls._initialize_node_visitors(stats, rel_file_path)
+        node_visitors_initialized = cls._initialize_node_visitors(
+            stats, rel_file_path
+        )
 
         for node_visitor_initialized in node_visitors_initialized:
             node_visitor_initialized.visit(node)

--- a/codewatch/node_visitor.py
+++ b/codewatch/node_visitor.py
@@ -88,8 +88,12 @@ def count_calling_files(stats_namespace, expected_callable_qname):
         callable_as_attribute = hasattr(call_node.func, "attrname")
         if callable_as_attribute:
             callable_name = call_node.func.attrname
+            node_to_infer = call_node.func.expr
+            build_qname = lambda inferred_type: inferred_type.qname() + callable_name
         else:
             callable_name = call_node.func.name
+            node_to_infer = call_node.func
+            build_qname = lambda inferred_type: inferred_type.qname()
 
         # Optimization: Start with a cheap guard before astroid inference
         if callable_name != expected_callable_name:
@@ -101,7 +105,7 @@ def count_calling_files(stats_namespace, expected_callable_qname):
             return call_node
 
         found_matching_inferred_qname = any(
-            inferred_type.qname() == expected_callable_qname
+            build_qname(inferred_type) == expected_callable_qname
             for inferred_type in inferred_types
         )
 

--- a/tests/config_modules/integration_config.py
+++ b/tests/config_modules/integration_config.py
@@ -4,14 +4,10 @@ This module is used by integration tests
 
 import os
 
-from codewatch import (
-    assertion,
-    visit,
-)
+from codewatch import assertion, visit
 
 from astroid import nodes, UseInferenceDefault, MANAGER
 from astroid.builder import AstroidBuilder
-
 
 
 # only visit this file itself
@@ -33,7 +29,9 @@ class A(object):
         def get():
             pass
 
+
 A.objects.get()
+
 
 def predicate(node):
     if not hasattr(node.func, "expr"):
@@ -59,15 +57,17 @@ def infer_objects_get_as_a(node, context=None):
         raise UseInferenceDefault()
 
     builder = AstroidBuilder(MANAGER)
-    m = builder.string_build("""\
+    m = builder.string_build(
+        """\
 class A(object):
     class objects(object):
         @staticmethod
         def get():
-            pass""")
+            pass"""
+    )
     class_node = m.body[0]
 
-    return ((class_node.instantiate_class(),))
+    return (class_node.instantiate_class(),)
 
 
 @visit(nodes.Call, change_node_inference=infer_objects_get_as_a)

--- a/tests/run/integration/test_runner.py
+++ b/tests/run/integration/test_runner.py
@@ -20,6 +20,7 @@ def test_full_run():
     successes, failures = _get_runner_for_config(integration_config).run()
     assert successes == [
         'custom_label_always_true',
+        'correctly_rewritten_inference',
         'expressions_more_than_zero',
         'num_import_from_more_than_zero',
     ]

--- a/tests/test_node_visitor.py
+++ b/tests/test_node_visitor.py
@@ -70,7 +70,11 @@ OuterClass2.inner.inner_method()"""
             NESTED_METHOD_IN_ATTR_CODE,
             "nested_method_in_attr_module",
             "nested_method_in_attr_module.InnerClass2.inner_method",
-            {"COUNT_NESTED_METHOD_IN_ATTR_CALLS": {"nested_method_in_attr_module.py": 1}},
+            {
+                "COUNT_NESTED_METHOD_IN_ATTR_CALLS": {
+                    "nested_method_in_attr_module.py": 1
+                }
+            },
         ),
     ],
 )

--- a/tests/test_node_visitor.py
+++ b/tests/test_node_visitor.py
@@ -9,43 +9,19 @@ from codewatch.node_visitor import (
 from codewatch.stats import Stats
 
 
-def test_sets_stats_and_file_path():
-    stats = Stats()
-    file_path = "/mock/path"
-    node_visitor = NodeVisitor(stats, file_path)
-
-    assert node_visitor.stats == stats
-    assert node_visitor.rel_file_path == file_path
-
-
-@pytest.mark.parametrize(
-    "stats_namespace,code,module_name,expected_callable_qname,expected_stats",
-    [
-        (
-            "COUNT_FUNCTION_CALLS",
-            """
+FUNCTION_CALL_CODE = """\
 def function():
     pass
-function()""",
-            "function_module",
-            "function_module.function",
-            {"COUNT_FUNCTION_CALLS": {"function_module.py": 1}},
-        ),
-        (
-            "COUNT_SIMPLE_METHOD_CALLS",
-            """\
+function()"""
+
+SIMPLE_METHOD_CODE = """\
 class SomeClass(object):
     @staticmethod
     def simple_method(self):
             pass
-SomeClass.simple_method()""",
-            "simple_method_module",
-            "simple_method_module.SomeClass.simple_method",
-            {"COUNT_SIMPLE_METHOD_CALLS": {"simple_method_module.py": 1}},
-        ),
-        (
-            "COUNT_NESTED_METHOD_CALLS",
-            """\
+SomeClass.simple_method()"""
+
+NESTED_METHOD_CODE = """\
 class InnerClass(object):
     def inner_method(self):
         pass
@@ -53,10 +29,48 @@ class InnerClass(object):
 class OuterClass(object):
     def outer_method(self):
         return InnerClass()
-OuterClass.outer_method().inner_method()""",
+OuterClass.outer_method().inner_method()"""
+
+NESTED_METHOD_IN_ATTR_CODE = """\
+class InnerClass2(object):
+    def inner_method(self):
+        pass
+
+class OuterClass2(object):
+    inner = InnerClass2()
+OuterClass2.inner.inner_method()"""
+
+
+@pytest.mark.parametrize(
+    "stats_namespace,code,module_name,expected_callable_qname,expected_stats",
+    [
+        (
+            "COUNT_FUNCTION_CALLS",
+            FUNCTION_CALL_CODE,
+            "function_module",
+            "function_module.function",
+            {"COUNT_FUNCTION_CALLS": {"function_module.py": 1}},
+        ),
+        (
+            "COUNT_SIMPLE_METHOD_CALLS",
+            SIMPLE_METHOD_CODE,
+            "simple_method_module",
+            "simple_method_module.SomeClass.simple_method",
+            {"COUNT_SIMPLE_METHOD_CALLS": {"simple_method_module.py": 1}},
+        ),
+        (
+            "COUNT_NESTED_METHOD_CALLS",
+            NESTED_METHOD_CODE,
             "nested_method_module",
             "nested_method_module.InnerClass.inner_method",
             {"COUNT_NESTED_METHOD_CALLS": {"nested_method_module.py": 1}},
+        ),
+        (
+            "COUNT_NESTED_METHOD_IN_ATTR_CALLS",
+            NESTED_METHOD_IN_ATTR_CODE,
+            "nested_method_in_attr_module",
+            "nested_method_in_attr_module.InnerClass2.inner_method",
+            {"COUNT_NESTED_METHOD_IN_ATTR_CALLS": {"nested_method_in_attr_module.py": 1}},
         ),
     ],
 )
@@ -77,3 +91,12 @@ def test_count_calling_files_function(
     NodeVisitorMaster.visit(stats, module, module_name + ".py")
 
     assert stats == expected_stats
+
+
+def test_sets_stats_and_file_path():
+    stats = Stats()
+    file_path = "/mock/path"
+    node_visitor = NodeVisitor(stats, file_path)
+
+    assert node_visitor.stats == stats
+    assert node_visitor.rel_file_path == file_path


### PR DESCRIPTION
In Django, models have a `.objects` attribute (of type `django.models.Manager`) that can be inferred when accessed (as the `.func.expr` in a `Call` node), but attempting to infer on the `.func` directly fails. This doesn't happen with other nested attributes, but is due to some "special Django magic" (which I haven't yet dug into).

This change works around the behaviour in Django by inferring in the place that works then reconstructing the full `qname`.