### PR TITLE
Send CircleCI Slack notifications for failures only on master branch.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -121,3 +121,9 @@ workflows:
             branches:
               only:
                 - master
+
+experimental:
+  notify:
+    branches:
+      only:
+        - master


### PR DESCRIPTION
This small change makes sure Slack notifications are only sent for failure on master branch.