### PR TITLE
fix Stats != equality check

### DIFF
--- a/codewatch/stats.py
+++ b/codewatch/stats.py
@@ -34,6 +34,9 @@ class Stats(object):
     def __eq__(self, other):
         return self.stats.__eq__(other)
 
+    def __ne__(self, other):
+        return self.stats.__ne__(other)
+
     def __getitem__(self, item):
         return self.stats.__getitem__(item)
 

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(
     name='codewatch',
     classifiers=CLASSIFIERS,
     packages=find_packages(),
-    version='0.0.8',
+    version='0.0.9',
     scripts=['bin/codewatch'],
     install_requires=[
         'astroid==1.6.4',  # 2.0 onwards is py3 only


### PR DESCRIPTION
This fix is needed for a `!=` check in python 2

https://docs.python.org/2/reference/datamodel.html#object.__ne__

```
There are no implied relationships among the comparison operators. The truth of x==y does not imply that x!=y is false. Accordingly, when defining __eq__(), one should also define __ne__() so that the operators will behave as expected.
```