### PR TITLE
test: normalize paths and subprocess for win compat for #81

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -90,6 +90,10 @@ ENV/
 env.bak/
 venv.bak/
 
+# IDEs
+.vs/
+.vscode/
+
 # Spyder project settings
 .spyderproject
 .spyproject

--- a/tests/run/integration/test_bin.py
+++ b/tests/run/integration/test_bin.py
@@ -2,19 +2,21 @@ import os
 import sys
 from subprocess import call
 
-from tests.config_modules import (
-    integration_config,
-    integration_config_utf8,
-)
+from tests.config_modules import integration_config, integration_config_utf8
 
 
 def _call_codewatch(pargs, **kwargs):
-    pythonexec = sys.executable or 'python'
-    codewatchbin = os.path.normcase('./bin/codewatch')
-    return call([pythonexec, codewatchbin] + pargs, shell=True, **kwargs) & 0xFF
+    bargs = []
+    if sys.platform == "win32":
+        bargs.append(sys.executable or "python")
+        bargs.append(os.path.normcase("./bin/codewatch"))
+        kwargs.update(shell=True)
+    else:
+        bargs.append("codewatch")
+    return call(bargs + pargs, **kwargs) & 0xFF
 
 
-def test_codewatch_returns_success():
+def test_codewatch_returns_correct_exit_code():
     ret = _call_codewatch([integration_config.__name__])
     assert ret == 255
 

--- a/tests/run/integration/test_bin.py
+++ b/tests/run/integration/test_bin.py
@@ -2,7 +2,10 @@ import os
 import sys
 from subprocess import call
 
-from tests.config_modules import integration_config, integration_config_utf8
+from tests.config_modules import (
+    integration_config,
+    integration_config_utf8,
+)
 
 
 def _call_codewatch(pargs, **kwargs):

--- a/tests/run/integration/test_bin.py
+++ b/tests/run/integration/test_bin.py
@@ -1,3 +1,5 @@
+import os
+import sys
 from subprocess import call
 
 from tests.config_modules import (
@@ -6,11 +8,17 @@ from tests.config_modules import (
 )
 
 
+def _call_codewatch(pargs, **kwargs):
+    pythonexec = sys.executable or 'python'
+    codewatchbin = os.path.normcase('./bin/codewatch')
+    return call([pythonexec, codewatchbin] + pargs, shell=True, **kwargs) & 0xFF
+
+
 def test_codewatch_returns_success():
-    ret = call(['codewatch', integration_config.__name__])
+    ret = _call_codewatch([integration_config.__name__])
     assert ret == 255
 
 
 def test_codewatch_utf8_returns_success():
-    ret = call(['codewatch', integration_config_utf8.__name__])
+    ret = _call_codewatch([integration_config_utf8.__name__])
     assert ret == 0

--- a/tests/run/test_analyzer.py
+++ b/tests/run/test_analyzer.py
@@ -13,8 +13,8 @@ from codewatch.stats import Stats
 MOCK_BASE_DIRECTORY_PATH = os.path.dirname(os.path.abspath(__file__))
 MOCK_FILE_NAMES = ("mockfile1.py", "mockfile2.py")
 RELATIVE_MOCK_FILE_PATHS = (
-    "mockdir/" + MOCK_FILE_NAMES[0],
-    "mockdir/" + MOCK_FILE_NAMES[1],
+    os.path.normcase("mockdir/" + MOCK_FILE_NAMES[0]),
+    os.path.normcase("mockdir/" + MOCK_FILE_NAMES[1]),
 )
 MOCK_FILES = [
     os.path.join(MOCK_BASE_DIRECTORY_PATH, RELATIVE_MOCK_FILE_PATHS[0]),

--- a/tests/test_file_walker.py
+++ b/tests/test_file_walker.py
@@ -1,19 +1,21 @@
+from os.path import (normcase, join)
 from codewatch.file_walker import FileWalker
+
 
 MOCK_PATHS = [
     ('.', ['dir1', 'dir2'], ['file1', 'file2', 'file3']),
-    ('./dir1', [], ['dir1_file1', 'dir1_file2']),
-    ('./dir2', ['dir2_subdir'], ['dir2_file1']),
-    ('./dir2/dir2_subdir', [], ['subdir_file1']),
+    (normcase('./dir1'), [], ['dir1_file1', 'dir1_file2']),
+    (normcase('./dir2'), ['dir2_subdir'], ['dir2_file1']),
+    (normcase('./dir2/dir2_subdir'), [], ['subdir_file1']),
 ]
 
-MOCK_START_PATH = '/home/mock'
+MOCK_START_PATH = normcase('/home/mock')
 
 
 def _expected_files_from_dir(dir_index):
     path = MOCK_PATHS[dir_index][0]
     files = MOCK_PATHS[dir_index][2]
-    return [path + '/' + file for file in files]
+    return [join(path, file) for file in files]
 
 
 def create_mock_os_walk(mock_path):


### PR DESCRIPTION
# Windows Compatibility for Testing

Addresses #81 (at least to get tests to pass as a first step).

- Wraps mock paths in os.path normalize case function which will convert forward slashes to backward slashes on Windows environments.
- use direct path to codewatch bin and manually specifies python executable since Windows does not support the shebang directive on executable scripts

## TODO
- [x] Test on Mac
- [x] Fix linting (python issues on my windows so switching to Mac to clean this up)