### PR TITLE
feat: add all-contributors-cli to keep contributors up to date automagically 

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -1,0 +1,102 @@
+{
+  "projectName": "codewatch",
+  "projectOwner": "tophat",
+  "repoType": "github",
+  "repoHost": "https://github.com",
+  "files": [
+    "README.md"
+  ],
+  "imageSize": 100,
+  "commit": false,
+  "contributors": [
+    {
+      "login": "lime-green",
+      "name": "Josh Doncaster Marsiglio",
+      "avatar_url": "https://avatars2.githubusercontent.com/u/9436142?v=4",
+      "profile": "https://github.com/lime-green",
+      "contributions": [
+        "code"
+      ]
+    },
+    {
+      "login": "rohit-jain27",
+      "name": "Rohit Jain",
+      "avatar_url": "https://avatars0.githubusercontent.com/u/18485117?v=4",
+      "profile": "https://github.com/rohit-jain27",
+      "contributions": [
+        "code"
+      ]
+    },
+    {
+      "login": "cabiad",
+      "name": "Chris Abiad",
+      "avatar_url": "https://avatars2.githubusercontent.com/u/840172?v=4",
+      "profile": "https://github.com/cabiad",
+      "contributions": [
+        "code"
+      ]
+    },
+    {
+      "login": "francoiscampbell",
+      "name": "Francois Campbell",
+      "avatar_url": "https://avatars.githubusercontent.com/u/3876970?v=4",
+      "profile": "https://github.com/francoiscampbell",
+      "contributions": [
+        "code"
+      ]
+    },
+    {
+      "login": "monicamm95",
+      "name": "Monica Moore",
+      "avatar_url": "https://avatars3.githubusercontent.com/u/8105535?v=4",
+      "profile": "https://monicamoore.ca",
+      "contributions": [
+        "design"
+      ]
+    },
+    {
+      "login": "jcrumb",
+      "name": "Jay Crumb",
+      "avatar_url": "https://avatars0.githubusercontent.com/u/7827407?v=4",
+      "profile": "https://github.com/jcrumb",
+      "contributions": [
+        "doc"
+      ]
+    },
+    {
+      "login": "jakebolam",
+      "name": "Jake Bolam",
+      "avatar_url": "https://avatars.githubusercontent.com/u/3534236?v=4",
+      "profile": "https://github.com/jakebolam",
+      "contributions": [
+        "infra"
+      ]
+    },
+    {
+      "login": "sdcosta",
+      "name": "Shouvik D'Costa",
+      "avatar_url": "https://avatars0.githubusercontent.com/u/6020693?v=4",
+      "profile": "https://github.com/sdcosta",
+      "contributions": [
+        "doc"
+      ]
+    },
+    {
+      "login": "syavash",
+      "name": "Siavash Bidgoly",
+      "avatar_url": "https://avatars1.githubusercontent.com/u/445636?v=4",
+      "profile": "https://github.com/syavash",
+      "contributions": [
+        "infra"
+      ]
+    },
+    {
+      "login": "noahnu",
+      "name": "Noah Negin-Ulster",
+      "avatar_url": "https://avatars0.githubusercontent.com/u/1297096?v=4",
+      "profile": "https://github.com/noahnu",
+      "contributions": [
+        "code"
+      ]
+    }
+}

--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -98,5 +98,24 @@
       "contributions": [
         "code"
       ]
+    },
+    {
+      "login": "vardan10",
+      "name": "Vardan Nadkarni",
+      "avatar_url": "https://avatars2.githubusercontent.com/u/20511260?v=4",
+      "profile": "https://github.com/vardan10",
+      "contributions": [
+        "code"
+      ]
+    },
+    {
+      "login": "greenkeeper[bot]",
+      "name": "greenkeeper[bot]",
+      "avatar_url": "https://avatars3.githubusercontent.com/in/505?v=4",
+      "profile": "https://github.com/apps/greenkeeper",
+      "contributions": [
+        "infra"
+      ]
     }
+  ]
 }

--- a/.gitignore
+++ b/.gitignore
@@ -113,5 +113,6 @@ test-reports
 # JS stuff for all contributors
 node_modules
 yarn.lock
+package-lock.json
 !website/yarn.lock
 

--- a/.gitignore
+++ b/.gitignore
@@ -109,3 +109,9 @@ venv.bak/
 
 # test reports
 test-reports
+
+# JS stuff for all contributors
+node_modules
+yarn.lock
+!website/yarn.lock
+

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,8 +1,4 @@
----
-id: contribute
-title: Contribute
----
-
+# Contributing
 View our [Code of Conduct](https://github.com/tophat/getting-started/blob/master/code-of-conduct.md)
 
 ## Running tests
@@ -21,7 +17,6 @@ Join the discussion on [slack](https://opensource.tophat.com/slack)!
 ## Add yourself as a Contributor
 To add yourself as a contributor:
 - `yarn install` or `npm install`
-- `yarn contributors:add` or `npm run contributors:add`
+- `yarn contributors:add`
 
 Contributions don't need to be code, they can come in many forms, check out the [emoji key](https://github.com/kentcdodds/all-contributors#emoji-key) for some examples.
-

--- a/README.md
+++ b/README.md
@@ -133,11 +133,16 @@ pytest
 ```
 
 # Contributors
+Thanks goes to these wonderful people [emoji key](https://github.com/kentcdodds/all-contributors#emoji-key):
 
-Thanks goes to these wonderful people! ([Emoji key](https://github.com/kentcdodds/all-contributors#emoji-key))
-
-<!-- ALL-CONTRIBUTORS-LIST: START - Do not remove or modify this section -->
+<!-- ALL-CONTRIBUTORS-LIST:START - Do not remove or modify this section -->
+<!-- prettier-ignore -->
+| [<img src="https://avatars2.githubusercontent.com/u/9436142?v=4" width="100px;"/><br /><sub><b>Josh Doncaster Marsiglio</b></sub>](https://github.com/lime-green)<br />[💻](https://github.com/tophat/codewatch/commits?author=lime-green "Code") | [<img src="https://avatars0.githubusercontent.com/u/18485117?v=4" width="100px;"/><br /><sub><b>Rohit Jain</b></sub>](https://github.com/rohit-jain27)<br />[💻](https://github.com/tophat/codewatch/commits?author=rohit-jain27 "Code") | [<img src="https://avatars2.githubusercontent.com/u/840172?v=4" width="100px;"/><br /><sub><b>Chris Abiad</b></sub>](https://github.com/cabiad)<br />[💻](https://github.com/tophat/codewatch/commits?author=cabiad "Code") | [<img src="https://avatars.githubusercontent.com/u/3876970?v=4" width="100px;"/><br /><sub><b>Francois Campbell</b></sub>](https://github.com/francoiscampbell)<br />[💻](https://github.com/tophat/codewatch/commits?author=francoiscampbell "Code") | [<img src="https://avatars3.githubusercontent.com/u/8105535?v=4" width="100px;"/><br /><sub><b>Monica Moore</b></sub>](https://monicamoore.ca)<br />[🎨](#design-monicamm95 "Design") | [<img src="https://avatars0.githubusercontent.com/u/7827407?v=4" width="100px;"/><br /><sub><b>Jay Crumb</b></sub>](https://github.com/jcrumb)<br />[📖](https://github.com/tophat/codewatch/commits?author=jcrumb "Documentation") | [<img src="https://avatars.githubusercontent.com/u/3534236?v=4" width="100px;"/><br /><sub><b>Jake Bolam</b></sub>](https://github.com/jakebolam)<br />[🚇](#infra-jakebolam "Infrastructure (Hosting, Build-Tools, etc)") |
+| :---: | :---: | :---: | :---: | :---: | :---: | :---: |
+| [<img src="https://avatars0.githubusercontent.com/u/6020693?v=4" width="100px;"/><br /><sub><b>Shouvik D'Costa</b></sub>](https://github.com/sdcosta)<br />[📖](https://github.com/tophat/codewatch/commits?author=sdcosta "Documentation") | [<img src="https://avatars1.githubusercontent.com/u/445636?v=4" width="100px;"/><br /><sub><b>Siavash Bidgoly</b></sub>](https://github.com/syavash)<br />[🚇](#infra-syavash "Infrastructure (Hosting, Build-Tools, etc)") | [<img src="https://avatars0.githubusercontent.com/u/1297096?v=4" width="100px;"/><br /><sub><b>Noah Negin-Ulster</b></sub>](https://github.com/noahnu)<br />[💻](https://github.com/tophat/codewatch/commits?author=noahnu "Code") | [<img src="https://avatars2.githubusercontent.com/u/20511260?v=4" width="100px;"/><br /><sub><b>Vardan Nadkarni</b></sub>](https://github.com/vardan10)<br />[💻](https://github.com/tophat/codewatch/commits?author=vardan10 "Code") | [<img src="https://avatars3.githubusercontent.com/in/505?v=4" width="100px;"/><br /><sub><b>greenkeeper[bot]</b></sub>](https://github.com/apps/greenkeeper)<br />[🚇](#infra-greenkeeper[bot] "Infrastructure (Hosting, Build-Tools, etc)") |
 <!-- ALL-CONTRIBUTORS-LIST:END -->
+
+We welcome contributions from the community, Top Hatters and non-Top Hatters alike. Check out our [contributing guidelines](CONTRIBUTING.md) for more details.
 
 # Credits
 

--- a/README.md
+++ b/README.md
@@ -119,18 +119,7 @@ Tune these filters to suit your needs.
 
 
 # Contributing
-View our Code of Conduct [here](https://github.com/tophat/getting-started/blob/master/code-of-conduct.md)
-
-## Running tests
-Assuming you have a suitable python version with pip:
-
-```bash
-# setup
-pip install -r requirements.txt -r requirements_test.txt
-
-# run the tests!
-pytest
-```
+See [the Contributing docs](CONTRIBUTING.md)
 
 # Contributors
 Thanks goes to these wonderful people [emoji key](https://github.com/kentcdodds/all-contributors#emoji-key):

--- a/README.md
+++ b/README.md
@@ -136,8 +136,7 @@ pytest
 
 Thanks goes to these wonderful people! ([Emoji key](https://github.com/kentcdodds/all-contributors#emoji-key))
 
-<!-- ALL-CONTRIBUTORS-LIST:START - Do not remove or modify this section -->
-<!-- prettier-ignore -->
+<!-- ALL-CONTRIBUTORS-LIST: START - Do not remove or modify this section -->
 <!-- ALL-CONTRIBUTORS-LIST:END -->
 
 # Credits

--- a/README.md
+++ b/README.md
@@ -10,6 +10,9 @@
 <br />
 
 [![Slack workspace](https://slackinvite.dev.tophat.com/badge.svg)](https://opensource.tophat.com/slack)
+<a href="#contributors">
+    <img alt="All Contributors" src="https://img.shields.io/badge/all_contributors-10-orange.svg?style=flat-square"/>
+</a>
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 [![Maturity badge - level 1](https://img.shields.io/badge/Maturity-Level%201%20--%20New%20Project-yellow.svg)](https://github.com/tophat/getting-started/blob/master/scorecard.md)
 
@@ -133,11 +136,9 @@ pytest
 
 Thanks goes to these wonderful people! ([Emoji key](https://github.com/kentcdodds/all-contributors#emoji-key))
 
-| [<img src="https://avatars2.githubusercontent.com/u/9436142?s=460&v=4" width="100px;"/><br /><sub><b>Josh Doncaster Marsiglio</b></sub>](https://github.com/lime-green)<br />[💻](https://github.com/tophat/codewatch/commits?author=lime-green)  | [<img src="https://avatars0.githubusercontent.com/u/18485117?s=460&v=4" width="100px;"/><br /><sub><b>Rohit Jain</b></sub>](https://github.com/rohit-jain27)<br />[💻](https://github.com/tophat/codewatch/commits?author=rohitjain-27) | [<img src="https://avatars2.githubusercontent.com/u/840172?s=460&v=4" width="100px;"/><br /><sub><b>Chris Abiad</b></sub>](https://github.com/cabiad)<br />[💻](https://github.com/tophat/codewatch/commits?author=cabiad) |
-| :---: | :---: | :---: |
-| [<img src="https://avatars.githubusercontent.com/u/3876970?s=100" width="100px;"/><br /><sub><b>Francois Campbell</b></sub>](https://github.com/francoiscampbell)<br />🤔[💻](https://github.com/tophat/codewatch/commits?author=francoiscampbell) | [<img src="https://avatars3.githubusercontent.com/u/8105535?s=100" width="100px;"/><br /><sub><b>Monica Moore</b></sub>](https://github.com/monicamm95)<br />🎨 | [<img src="https://avatars0.githubusercontent.com/u/7827407?s=100" width="100px;"/><br /><sub><b>Jay Crumb</b></sub>](https://github.com/jcrumb)<br />[📖](https://github.com/tophat/codewatch/commits?author=jcrumb) |
-| [<img src="https://avatars.githubusercontent.com/u/3534236?s=100" width="100px;"/><br /><sub><b>Jake Bolam</b></sub>](https://github.com/jakebolam)<br />[🚇](https://github.com/tophat/codewatch/commits?author=jakebolam) | [<img src="https://avatars0.githubusercontent.com/u/6020693?s=100" width="100px;"/><br /><sub><b>Shouvik D'Costa</b></sub>](https://github.com/sdcosta)<br />[🚇](https://github.com/tophat/codewatch/commits?author=sdcosta) | [<img src="https://avatars1.githubusercontent.com/u/445636?s=100" width="100px;"/><br /><sub><b>Siavash Bidgoly</b></sub>](https://github.com/syavash)<br />[🚇](https://github.com/tophat/codewatch/commits?author=syavash) |
-| [<img src="https://avatars0.githubusercontent.com/u/1297096?s=100" width="100px;"/><br /><sub><b>Noah Negin-Ulster</b></sub>](https://github.com/noahnu)<br />[💻](https://github.com/tophat/codewatch/commits?author=noahnu)
+<!-- ALL-CONTRIBUTORS-LIST:START - Do not remove or modify this section -->
+<!-- prettier-ignore -->
+<!-- ALL-CONTRIBUTORS-LIST:END -->
 
 # Credits
 

--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "codewatch",
+  "description": "This package.json is just to manage all-contributors",
+  "private": true,
+  "scripts": {
+    "contributors:add": "all-contributors add",
+    "contributors:generate": "all-contributors generate",
+    "contributors:check": "all-contributors check"
+  },
+  "devDependencies": {
+    "all-contributors-cli": "^5.4.1"
+  }
+}


### PR DESCRIPTION
# Overview
Added all-contributors-cli to manage contributors easily.
Added missing credits:
- vardan10 for code
- greenkeeper-bot for ci

You can [view the markdown changes here](https://github.com/tophat/codewatch/blob/c28db561a6b8b8247b9d80c00cc6405b92c81c33/README.md#contributors)

# Notes:
Ran into a bunch of github API limits that are affecting yvm and all contributors. And opened some PR's there too: https://github.com/tophat/yvm/issues/255, https://github.com/jfmengels/all-contributors-cli/issues/121 https://github.com/jfmengels/all-contributors-cli/pull/122/files