### PR TITLE
fix: use full relative path for dir filter and only traverse match

### DIFF
--- a/codewatch/file_walker.py
+++ b/codewatch/file_walker.py
@@ -17,9 +17,12 @@ class FileWalker(object):
 
     def walk(self):
         for path, directories, files in self.walk_fn(self.base_directory_path):
-            rel_path = relpath(path, self.base_directory_path)
-            path_basename = basename(path)
-            if rel_path != '.' and not self.directory_filter(path_basename):
+            directories[:] = [
+                d for d in directories
+                if self.directory_filter(join(path, d))
+            ]
+
+            if not self.directory_filter(path):
                 continue
 
             for file in files:

--- a/codewatch/file_walker.py
+++ b/codewatch/file_walker.py
@@ -13,12 +13,14 @@ class FileWalker(object):
 
     def walk(self):
         for path, directories, files in self.walk_fn(self.base_directory_path):
+            print('path is', path)
             directories[:] = [
                 d for d in directories
                 if self.directory_filter(join(path, d))
             ]
 
             if not self.directory_filter(path):
+                print('nope')
                 continue
 
             for file in files:

--- a/codewatch/file_walker.py
+++ b/codewatch/file_walker.py
@@ -1,9 +1,5 @@
 from os import walk as os_walk
-from os.path import (
-    basename,
-    join,
-    relpath,
-)
+from os.path import join
 
 
 class FileWalker(object):

--- a/codewatch/file_walker.py
+++ b/codewatch/file_walker.py
@@ -13,15 +13,10 @@ class FileWalker(object):
 
     def walk(self):
         for path, directories, files in self.walk_fn(self.base_directory_path):
-            print('path is', path)
             directories[:] = [
                 d for d in directories
                 if self.directory_filter(join(path, d))
             ]
-
-            if not self.directory_filter(path):
-                print('nope')
-                continue
 
             for file in files:
                 if not self.file_filter(file):

--- a/tests/test_file_walker.py
+++ b/tests/test_file_walker.py
@@ -66,6 +66,7 @@ def test_it_filters_on_directories():
     )
     assert _walk(directory_filter, file_filter) == expected_files_walked
 
+
 def test_it_filters_on_files():
     def directory_filter(_path):
         return True

--- a/tests/test_file_walker.py
+++ b/tests/test_file_walker.py
@@ -1,4 +1,5 @@
 from os.path import (normcase, join)
+from copy import deepcopy
 from codewatch.file_walker import FileWalker
 
 
@@ -21,7 +22,7 @@ def _expected_files_from_dir(dir_index):
 def create_mock_os_walk(mock_path):
     def _os_walk(path):
         assert path == mock_path
-        return MOCK_PATHS
+        return deepcopy(MOCK_PATHS)
     return _os_walk
 
 
@@ -64,7 +65,6 @@ def test_it_filters_on_directories():
         _expected_files_from_dir(1)
     )
     assert _walk(directory_filter, file_filter) == expected_files_walked
-
 
 def test_it_filters_on_files():
     def directory_filter(_path):

--- a/tests/test_file_walker.py
+++ b/tests/test_file_walker.py
@@ -76,7 +76,7 @@ def test_it_can_walk_all_files():
 
 def test_it_filters_on_directories():
     def directory_filter(path):
-        return 'dir2_subdir' not in basename(path)
+        return 'dir2_subdir' != basename(path)
 
     def file_filter(_path):
         return True

--- a/tests/test_file_walker.py
+++ b/tests/test_file_walker.py
@@ -1,4 +1,4 @@
-from os.path import (normcase, join, normpath)
+from os.path import (basename, normcase, join, normpath)
 from copy import deepcopy
 from codewatch.file_walker import FileWalker
 
@@ -75,6 +75,21 @@ def test_it_can_walk_all_files():
 
 
 def test_it_filters_on_directories():
+    def directory_filter(path):
+        return 'dir2_subdir' not in basename(path)
+
+    def file_filter(_path):
+        return True
+
+    expected_files_walked = (
+        _expected_files_from_dir(0) +
+        _expected_files_from_dir(1) +
+        _expected_files_from_dir(2)
+    )
+    assert _walk(directory_filter, file_filter) == expected_files_walked
+
+
+def test_does_not_walk_subdirectories_if_parent_is_filtered():
     def directory_filter(path):
         return path != normcase('./dir2')
 

--- a/tests/test_file_walker.py
+++ b/tests/test_file_walker.py
@@ -35,12 +35,14 @@ def create_mock_os_walk(mock_path):
             yield root
             for _dir in root[1]:
                 dirpath = join(base_path, _dir)
-                yield from _find_paths(mock_paths, dirpath)
+                for subpath in _find_paths(mock_paths, dirpath):
+                    yield subpath
 
     def _os_walk(path):
         assert path == mock_path
         mock_paths = deepcopy(MOCK_PATHS)
-        yield from _find_paths(mock_paths, path)
+        for subpath in _find_paths(mock_paths, path):
+            yield subpath
 
     return _os_walk
 


### PR DESCRIPTION
Addresses: https://github.com/tophat/codewatch/issues/77

Two changes, both **breaking changes**:
- directory_filter now receives full path of directory relative to base directory. Previously, it only received the directory basename.
- FileWalker will no longer traverse subdirectories that do not match the directory_filter. Previously, it traversed all directories.

One of the issues with the old behaviour:
- A directory_filter with `return _dir != '.git'` would still traverse the _entire_ .git directory tree. Although it wouldn't attempt to parse these files b/c the file_filter defaults to only look at ".py", it would still have to test the path. This adds an extreme performance overhead to running codewatch on even a moderately large directory tree.

## Tests

Updated `test_it_filters_on_directories` to be stronger. It now tests using the full relative path "./dir2" rather than just a substring match. Since `dir2_subdir` will not match "./dir2", the test must be passing b/c the directory walker is successfully pruning the dir2 folder. Had to update the mock walker to actually work like the real os walk function (i.e. rely on a mutable directory list).