### PR TITLE
fix: dynamic astroid version for py version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,15 +24,10 @@ CLASSIFIERS = [
 ]
 
 
-if sys.version_info[0:3] >= (3, 6, 0):
-    # astroid<2.0 does not work on python>=3.7 because StopIteration is removed
-    INSTALL_REQUIRES = [
-        'astroid==2.0.4'
-    ]
-else:
-    INSTALL_REQUIRES = [
-        'astroid==1.6.4',  # 2.0 onwards is py3 only
-    ]
+INSTALL_REQUIRES = [
+    'astroid==2.0.4; python_version>="3"',
+    'astroid==1.6.4; python_version<"3"',  # 2.0 onwards is py3 only
+]
 
 base_dir = os.path.dirname(__file__)
 readme_path = join(base_dir, 'README.md')

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ setup(
     name='codewatch',
     classifiers=CLASSIFIERS,
     packages=find_packages(),
-    version='0.0.18',
+    version='0.0.19',
     description="Monitor and manage deeply customizable metrics about your python code using ASTs",
     long_description=long_description,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
Fixes codewatch installation on python2 systems

The wheel file built by codewatch was built in a python 3 environment, and the install requires was dynamically set in `setup.py` according to the python version there. The wheel file then had a dependency on the python 3 astroid version. Strangely enough the `sdist` package worked fine.
Now using this approach: https://www.python.org/dev/peps/pep-0508/#environment-markers

### DevQA
```
rm dist/*
pip3 install wheel
python3 setup.py sdist bdist_wheel
pip2 install dist/codewatch-*.whl # make sure this installs astroid 1.6.4
pip3 install dist/codewatch-*.whl # make this installs astroid 2.0.4
```
