### PR TITLE
fix: a bunch of things I noticed

### DIFF
--- a/codewatch/assertion.py
+++ b/codewatch/assertion.py
@@ -8,7 +8,7 @@ def _get_assertion_failure_message(assertion_failure):
     if there's an assertion error message return that
     otherwise, return the code line the assertion is called from
     """
-    if len(assertion_failure.args) > 0:
+    if assertion_failure.args:
         return assertion_failure.args[0]
     tb_info = extract_tb(exc_info()[2])
     return tb_info[-1][3]

--- a/codewatch/assertion.py
+++ b/codewatch/assertion.py
@@ -10,7 +10,11 @@ def _get_assertion_failure_message(assertion_failure):
     """
     if assertion_failure.args:
         return assertion_failure.args[0]
+    # extract_tb returns a StackSummary, which wraps a list of FrameSummary
     tb_info = extract_tb(exc_info()[2])
+    # FrameSummary contains:
+    # (self.filename, self.lineno, self.name, self.line)
+    # Get the last FrameSummary then get the line's text
     return tb_info[-1][3]
 
 

--- a/codewatch/assertion.py
+++ b/codewatch/assertion.py
@@ -1,4 +1,17 @@
 from functools import wraps
+from sys import exc_info
+from traceback import extract_tb
+
+
+def _get_assertion_failure_message(assertion_failure):
+    """
+    if there's an assertion error message return that
+    otherwise, return the code line the assertion is called from
+    """
+    if len(assertion_failure.args) > 0:
+        return assertion_failure.args[0]
+    tb_info = extract_tb(exc_info()[2])
+    return tb_info[-1][3]
 
 
 class Assertion(object):
@@ -28,7 +41,9 @@ class Assertion(object):
             try:
                 assertion_fn(self.stats)
             except AssertionError as assertion_failure:
-                failures[assertion_label] = assertion_failure.args[0]
+                failures[assertion_label] = _get_assertion_failure_message(
+                    assertion_failure,
+                )
             except Exception as error:
                 errors[assertion_label] = error
             else:

--- a/codewatch/helpers/visitor.py
+++ b/codewatch/helpers/visitor.py
@@ -12,6 +12,14 @@ from codewatch.node_visitor import NodeVisitorMaster
 
 
 def visit(node_type, predicate=None, inferences=None):
+    """
+    Functions decorated with `visit` are called on nodes of type `node_type`
+    eg: To count the number of imports in each file
+
+    @visit('import')
+    def my_visitor(node, stats, rel_file_path):
+        stats['imports'].increment(rel_file_path)
+    """
     def decorator(fn):
         NodeVisitorMaster.register_visitor(
             node_type, fn, predicate, inferences,
@@ -21,7 +29,19 @@ def visit(node_type, predicate=None, inferences=None):
     return decorator
 
 
+def _validate_stats_namespace(stats_namespace):
+    if stats_namespace is None:
+        raise Exception("count_calling_files() requires a valid namespace")
+
+
 def count_import_usages(stats_namespace, expected_qname, importer=None):
+    """
+    A visitor to track the number of times a particular attribute is imported
+    eg: To track the number of times the User model is imported
+
+    count_import_usages('imports_num_user_model', 'app.models.User')
+    """
+    _validate_stats_namespace(stats_namespace)
     if importer is None:
         importer = importlib.import_module
 
@@ -41,7 +61,7 @@ def count_import_usages(stats_namespace, expected_qname, importer=None):
         modname = import_from_node.modname
 
         for name, alias in import_from_node.names:
-            if name == '*':
+            if name == '*' and module_name == modname:
                 module = importer(module_name)
                 if trouble_attribute in dir(module):
                     track_import(stats, rel_file_path)
@@ -60,9 +80,7 @@ def count_calling_files(
         expected_callable_qname,
         inferences=None,
 ):
-    if stats_namespace is None:
-        raise Exception("count_calling_files() requires a valid namespace")
-
+    _validate_stats_namespace(stats_namespace)
     expected_callable_name = expected_callable_qname.split(".")[-1]
 
     def record_stats(stats, rel_file_path):
@@ -116,7 +134,8 @@ def count_calls_on_django_model(stats_namespace, model_qname, method_name):
     Populates stats with the number of calls per file
 
     eg:
-    count_calls_on_model('destroy_calls', 'app.lobby.models.User', 'destroy')
+    count_calls_on_django_model(
+      'destroy_calls', 'app.lobby.models.User', 'destroy')
 
     stats => {'destroy_calls': {'app/lobby/views.py': 15}}
 

--- a/codewatch/helpers/visitor.py
+++ b/codewatch/helpers/visitor.py
@@ -29,9 +29,9 @@ def visit(node_type, predicate=None, inferences=None):
     return decorator
 
 
-def _validate_stats_namespace(stats_namespace):
+def _validate_stats_namespace(fn_name, stats_namespace):
     if stats_namespace is None:
-        raise Exception("count_calling_files() requires a valid namespace")
+        raise Exception("{} requires a valid namespace".format(fn_name))
 
 
 def count_import_usages(stats_namespace, expected_qname, importer=None):
@@ -41,7 +41,7 @@ def count_import_usages(stats_namespace, expected_qname, importer=None):
 
     count_import_usages('imports_num_user_model', 'app.models.User')
     """
-    _validate_stats_namespace(stats_namespace)
+    _validate_stats_namespace('count_import_usages', stats_namespace)
     if importer is None:
         importer = importlib.import_module
 
@@ -80,7 +80,7 @@ def count_calling_files(
         expected_callable_qname,
         inferences=None,
 ):
-    _validate_stats_namespace(stats_namespace)
+    _validate_stats_namespace('count_calling_files', stats_namespace)
     expected_callable_name = expected_callable_qname.split(".")[-1]
 
     def record_stats(stats, rel_file_path):
@@ -142,6 +142,8 @@ def count_calls_on_django_model(stats_namespace, model_qname, method_name):
     This indicates the the destroy() function was called 15 times on the
     User model in app/lobby/views.py
     """
+    _validate_stats_namespace('count_calls_on_django_model', stats_namespace)
+
     def record_stats(stats, rel_file_path):
         stats = stats.namespaced(stats_namespace)
         stats.increment(rel_file_path)

--- a/tests/config_modules/django_usage.py
+++ b/tests/config_modules/django_usage.py
@@ -1,6 +1,3 @@
-# -*- coding: utf-8 -*-
-
-
 class DjangoUser(object):
     def dangerous_method(self):
         pass

--- a/tests/config_modules/django_usage.py
+++ b/tests/config_modules/django_usage.py
@@ -1,3 +1,6 @@
+# -*- coding: utf-8 -*-
+
+
 class DjangoUser(object):
     def dangerous_method(self):
         pass

--- a/tests/mock_data.py
+++ b/tests/mock_data.py
@@ -17,6 +17,11 @@ def unsuccessful_assertion(_stats):
 
 
 @assertion()
+def unsuccessful_assertion_no_message(_stats):
+    assert False
+
+
+@assertion()
 def erroring_assertion(_stats):
     raise MOCK_ERR
 

--- a/tests/run/test_analyzer.py
+++ b/tests/run/test_analyzer.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 import os
+import re
 from contextlib import contextmanager
 from io import StringIO
 
@@ -163,7 +164,7 @@ def test_parse_errors_are_rethrown():
     expected_err = (
         'An exception occurred while parsing file: '
         '.*{}'.format(
-            os.path.join(MOCK_DIR_NAME, MOCK_FILE_NAMES[0]),
+            re.escape(os.path.join(MOCK_DIR_NAME, MOCK_FILE_NAMES[0])),
         )
     )
 

--- a/tests/run/test_analyzer.py
+++ b/tests/run/test_analyzer.py
@@ -160,7 +160,12 @@ def test_parse_errors_are_rethrown():
     )
     analyzer.override_node_visitor_master(MockNodeMaster)
 
-    expected_err = 'An exception occurred while parsing file: ' \
-                   '.*{}/{}'.format(MOCK_DIR_NAME, MOCK_FILE_NAMES[0])
+    expected_err = (
+        'An exception occurred while parsing file: '
+        '.*{}'.format(
+            os.path.join(MOCK_DIR_NAME, MOCK_FILE_NAMES[0]),
+        )
+    )
+
     with pytest.raises(ParseException, match=expected_err):
         analyzer.run(Stats())

--- a/tests/run/test_analyzer.py
+++ b/tests/run/test_analyzer.py
@@ -6,15 +6,19 @@ from io import StringIO
 
 import astroid
 import pytest
-from codewatch.run import Analyzer
+from codewatch.run import (
+    Analyzer,
+    ParseException,
+)
 from codewatch.stats import Stats
 
 
 MOCK_BASE_DIRECTORY_PATH = os.path.dirname(os.path.abspath(__file__))
+MOCK_DIR_NAME = "mockdir"
 MOCK_FILE_NAMES = ("mockfile1.py", "mockfile2.py")
 RELATIVE_MOCK_FILE_PATHS = (
-    os.path.normcase("mockdir/" + MOCK_FILE_NAMES[0]),
-    os.path.normcase("mockdir/" + MOCK_FILE_NAMES[1]),
+    os.path.normcase(MOCK_DIR_NAME + "/" + MOCK_FILE_NAMES[0]),
+    os.path.normcase(MOCK_DIR_NAME + "/" + MOCK_FILE_NAMES[1]),
 )
 MOCK_FILES = [
     os.path.join(MOCK_BASE_DIRECTORY_PATH, RELATIVE_MOCK_FILE_PATHS[0]),
@@ -66,8 +70,15 @@ class MockParser(object):
         return self.mock_tree
 
 
+class MockErrorParser(MockParser):
+    ERR_MSG = 'my error message'
+
+    def parse(self, *args, **kwargs):
+        raise Exception(self.ERR_MSG)
+
+
 def _test_visits_file_with_ast_tree_and_relative_path(
-    mock_file_contents, expected_file_contents_for_parsing
+    mock_file_contents, expected_file_contents_for_parsing,
 ):
     mock_tree = astroid.Module(doc="", name="mock_module")
     file_opener = MockFileOpener(mock_file_contents)
@@ -135,5 +146,21 @@ def test_visits_file_with_ast_tree_and_relative_path(
     file, expected_file_contents_for_parsing
 ):
     _test_visits_file_with_ast_tree_and_relative_path(
-        file, expected_file_contents_for_parsing
+        file, expected_file_contents_for_parsing,
     )
+
+
+def test_parse_errors_are_rethrown():
+    mock_tree = astroid.Module(doc="", name="mock_module")
+    file_opener = MockFileOpener('')
+    file_walker = MockFileWalker(MOCK_FILES)
+    parser = MockErrorParser(mock_tree)
+    analyzer = Analyzer(
+        MOCK_BASE_DIRECTORY_PATH, file_walker, file_opener.open, parser.parse
+    )
+    analyzer.override_node_visitor_master(MockNodeMaster)
+
+    expected_err = 'An exception occurred while parsing file: ' \
+                   '.*{}/{}'.format(MOCK_DIR_NAME, MOCK_FILE_NAMES[0])
+    with pytest.raises(ParseException, match=expected_err):
+        analyzer.run(Stats())

--- a/tests/test_assertion.py
+++ b/tests/test_assertion.py
@@ -16,6 +16,7 @@ from tests.mock_data import (
     stats_assertion,
     successful_assertion,
     unsuccessful_assertion,
+    unsuccessful_assertion_no_message,
 )
 
 
@@ -36,6 +37,18 @@ def test_unsuccessful_assertion():
     ).run()
     assert successes == []
     assert failures == {unsuccessful_assertion.__name__: MOCK_FAILURE_MSG}
+    assert errors == {}
+
+
+def test_unsuccessful_assertion_no_message():
+    successes, failures, errors = Assertion(
+        Stats(),
+        [unsuccessful_assertion_no_message],
+    ).run()
+    assert successes == []
+    assert failures == {
+        unsuccessful_assertion_no_message.__name__: 'assert False',
+    }
     assert errors == {}
 
 


### PR DESCRIPTION
I did some code review of the project and noticed a few quick wins:

- Raise a `ParseException` with the name of the file if an exception is raised during parsing (previously an astroid error would be raised, but no filename). It still prints the astroid error too now
- If no assertion message is given by the user (`assert 1 == 2`), use the code line where the assertion is called as a label (previously it would error in the assertion processing code which was very confusing!)
- Add more docstrings